### PR TITLE
LMP revert to 3.2.1

### DIFF
--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/finish/frontendUI/pom.xml
+++ b/finish/frontendUI/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/start/frontendUI/pom.xml
+++ b/start/frontendUI/pom.xml
@@ -54,7 +54,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.1</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>


### PR DESCRIPTION
Revert `liberty-maven-plugin` in `pom.xml` to 3.2.1 to address issue that came up during GM candidate testing

```
[ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.2.2:dev (default-cli) on project backendServices: CWWKM2004E: When installDir is set, it must point to a directory that contains lib/ws-launch.jar. -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.2.2:dev (default-cli) on project backendServices: CWWKM2004E: When installDir is set, it must point to a directory that contains lib/ws-launch.jar.
```