### PR TITLE
Fix for travis test

### DIFF
--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -96,6 +96,9 @@
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
+                        <configuration>
+                            <includeArtifactIds>derby</includeArtifactIds>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -96,10 +96,6 @@
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
-                        <configuration>
-                            <includeArtifactIds>derby</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}/liberty/wlp/usr/shared/resources/</outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -96,6 +96,9 @@
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
+                        <configuration>
+                            <includeArtifactIds>derby</includeArtifactIds>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -96,10 +96,6 @@
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>
-                        <configuration>
-                            <includeArtifactIds>derby</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}/liberty/wlp/usr/shared/resources/</outputDirectory>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Testing with nightly build fails with following error:

> [ERROR] Failed to execute goal io.openliberty.tools:liberty-maven-plugin:3.2.3:create (default-cli) on project backendServices: CWWKM2004E: When installDir is set, it must point to a directory that contains lib/ws-launch.jar. -> [Help 1]
> [ERROR] 
> [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
> [ERROR] Re-run Maven using the -X switch to enable full debug logging.
> [ERROR] 
> [ERROR] For more information about the errors and possible solutions, please read the following articles:
> [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException

Occurs when manually running `travisTest.sh` and when triggered by daily builds. 

This fix should solve this