### PR TITLE
Use the derby version that support Java 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         java-version: 8
     - run: unset _JAVA_OPTIONS
     - name: Run tests
-      run: sudo ../scripts/testApp.sh
+      run: sudo -E ../scripts/testApp.sh
     - name: Post tests
       if: always()
       run: |

--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -60,27 +60,15 @@
             <scope>test</scope>
         </dependency>
         <!-- Derby from https://mvnrepository.com/artifact/org.apache.derby/derby -->
+        <!-- Use 10.14.2 that support Java 8. If use 10.15+, -->
+        <!-- need to use Java 9+, and -->
+        <!-- add 2 more derby dependencies: derbytools and derbyshared -->
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.14.2.0</version>
             <scope>provided</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.derby/derbytools -->
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.derby/derbyshared -->
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyshared</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.14.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -60,27 +60,15 @@
             <scope>test</scope>
         </dependency>
         <!-- Derby from https://mvnrepository.com/artifact/org.apache.derby/derby -->
+        <!-- Use 10.14.2 that support Java 8. If use 10.15+, -->
+        <!-- need to use Java 9+, and -->
+        <!-- add 2 more derby dependencies: derbytools and derbyshared -->
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
             <version>10.15.2.0</version>
             <scope>provided</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.derby/derbytools -->
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbytools</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.apache.derby/derbyshared -->
-        <dependency>
-            <groupId>org.apache.derby</groupId>
-            <artifactId>derbyshared</artifactId>
-            <version>10.15.2.0</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
     <build>
         <finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
The derby 10.15.2 requires Java 9+. Update the backendServices/pom.xml files to use derby 10.14.2.0 so that the guide can run with Java 8.