### PR TITLE
Remove EclipseLink specific DDL properties

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -250,7 +250,7 @@ server.xml
 include::finish/backendServices/src/main/liberty/config/server.xml[]
 ----
 
-The [hotspot=eclipse-link file=0]`eclipselink.ddl-generation` properties are used here so that you aren't required to manually create a database table to run this sample application. To learn more about the `ddl-generation` properties, see the http://www.eclipse.org/eclipselink/documentation/2.5/jpa/extensions/p_ddl_generation.htm[JPA Extensions Reference for EclipseLink.^]
+The [hotspot=schema-generation file=0]`jakarta.persistence.schema-generation` properties are used here so that you aren't required to manually create a database table to run this sample application. To learn more about the JPA schema generation and available properties, see https://jakarta.ee/specifications/persistence/3.0/jakarta-persistence-spec-3.0.html#a12917[Schema Generation, Section 9.4 of the JPA Specification]
 
 // =================================================================================================
 // Performing CRUD operations using JPA

--- a/finish/backendServices/src/main/resources/META-INF/persistence.xml
+++ b/finish/backendServices/src/main/resources/META-INF/persistence.xml
@@ -12,10 +12,11 @@
         <jta-data-source>jdbc/eventjpadatasource</jta-data-source>
         <!-- end::jta-data[] -->
         <properties>
-        <!-- tag::eclipse-link[] -->
-            <property name="eclipselink.ddl-generation" value="create-tables"/>
-            <property name="eclipselink.ddl-generation.output-mode" value="both" />
-        <!-- end::eclipse-link[] -->
+        <!-- tag::schema-generation[] -->
+            <property name="jakarta.persistence.schema-generation.database.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.scripts.action" value="create"/>
+            <property name="jakarta.persistence.schema-generation.scripts.create-target" value="createDDL.ddl"/>
+        <!-- end::schema-generation[] -->
         </properties>
     </persistence-unit>
     <!-- end::persistence-unit[] -->


### PR DESCRIPTION
The JPA Intro guide uses EclipseLink specific persistence properties for DDL generation. It is not preferable to use provider specific properties (eclipselink.) when there are equivalent specification defined properties (javax.)

Signed-off-by: William Dazey <wadazey@us.ibm.com>