### PR TITLE
Merge staging to prod - Bump org.apache.derby:derby from 10.15.2.0 to 10.17.1.0 in /finish/ba…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,11 +44,12 @@ jobs:
       run:
         working-directory: finish
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        distribution: 'semeru'
+        java-version: 21
     - run: unset _JAVA_OPTIONS
     - name: Run tests
       run: sudo -E ../scripts/testApp.sh
@@ -57,6 +58,7 @@ jobs:
       run: |
           logsPath=$(sudo find . -name "console.log");
           sudo cat $logsPath | sudo grep Launching
+          sudo chmod -R a+xr $logsPath
     - name: Archive backend logs if failed
       if: failure()
       uses: actions/upload-artifact@v2

--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -65,19 +65,19 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyshared</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbytools</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -87,13 +87,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
                 <configuration>
                     <copyDependencies>
                         <location>${project.build.directory}/liberty/wlp/usr/shared/resources</location>
@@ -116,13 +116,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <backend.http.port>${backend.service.http.port}</backend.http.port>

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/event/EventEntityIT.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/event/EventEntityIT.java
@@ -22,7 +22,6 @@ import jakarta.ws.rs.core.Response.Status;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Test;
 import io.openliberty.guides.event.models.Event;
 

--- a/finish/frontendUI/pom.xml
+++ b/finish/frontendUI/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -48,25 +48,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <frontend.service.http.port>${frontend.service.http.port}</frontend.service.http.port>

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
-while getopts t:d: flag;
+while getopts t:d:j: flag;
 do
     case "${flag}" in
         t) DATE="${OPTARG}" ;;
         d) DRIVER="${OPTARG}" ;;
+        j) JDK_LEVEL="${OPTARG}" ;;
         *) echo "Invalid option input" ;;
     esac
 done
+
+if [ "$JDK_LEVEL" == "11" ]; then
+    echo "Test skipped because the guide does not support Java 11."
+    exit 0
+fi
 
 sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#a<configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install></configuration>" frontendUI/pom.xml
 cat frontendUI/pom.xml

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -38,19 +38,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -65,19 +65,19 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derby</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbyshared</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbytools</artifactId>
-            <version>10.15.2.0</version>
+            <version>10.17.1.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -87,13 +87,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
                 <configuration>
                     <copyDependencies>
                         <location>${project.build.directory}/liberty/wlp/usr/shared/resources</location>
@@ -116,13 +116,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <backend.http.port>${backend.service.http.port}</backend.http.port>

--- a/start/frontendUI/pom.xml
+++ b/start/frontendUI/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -48,25 +48,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
+                <version>3.4.0</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run integration tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <frontend.service.http.port>${frontend.service.http.port}</frontend.service.http.port>


### PR DESCRIPTION
…ckendServices (#209)

* Bump org.apache.derby:derby in /finish/backendServices

Bumps org.apache.derby:derby from 10.15.2.0 to 10.17.1.0.

---
updated-dependencies:
- dependency-name: org.apache.derby:derby dependency-type: direct:production ...



* Bump org.apache.derby:derby in /start/backendServices

Bumps org.apache.derby:derby from 10.15.2.0 to 10.17.1.0.

---
updated-dependencies:
- dependency-name: org.apache.derby:derby dependency-type: direct:production ...



* Update pom.xml

* Update pom.xml

* Update pom.xml

* Update pom.xml

* Update test.yml

* Update dailyBuild.sh

* Update test.yml

* Update pom.xml

* Update pom.xml

* Update test.yml

* Update pom.xml

* Update pom.xml

* Update pom.xml

* Update pom.xml

* Update test.yml

* Update EventEntityIT.java

* Update test.yml (#213)

* Update pom.xml

* Update pom.xml

* Update pom.xml

* Update pom.xml

---------