### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/backendServices/src/main/liberty/config/server.xml
+++ b/finish/backendServices/src/main/liberty/config/server.xml
@@ -8,10 +8,10 @@
     <feature>persistence-3.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="5050" />
-  <variable name="default.https.port" defaultValue="5051" />
+  <variable name="http.port" defaultValue="5050" />
+  <variable name="https.port" defaultValue="5051" />
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
                 id="defaultHttpEndpoint" host="*" />
 
   <application location="backendServices.war" type="war" context-root="/"></application>

--- a/finish/frontendUI/pom.xml
+++ b/finish/frontendUI/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/finish/frontendUI/src/main/liberty/config/server.xml
+++ b/finish/frontendUI/src/main/liberty/config/server.xml
@@ -6,14 +6,14 @@
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
     <feature>faces-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9090"/>
-  <variable name="default.https.port" defaultValue="9091"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9091"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
     id="defaultHttpEndpoint" host="*" />
 
   <application location="frontendUI.war" context-root="/">

--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -17,7 +17,7 @@ fi
 sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#a<configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install></configuration>" frontendUI/pom.xml
 cat frontendUI/pom.xml
 
-sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.7.1</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" backendServices/pom.xml
+sed -i "\#<artifactId>liberty-maven-plugin</artifactId>#,\#<configuration>#c<artifactId>liberty-maven-plugin</artifactId><version>3.10</version><configuration><install><runtimeUrl>https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/nightly/$DATE/$DRIVER</runtimeUrl></install>" backendServices/pom.xml
 cat backendServices/pom.xml
 
 ../scripts/testApp.sh

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/start/backendServices/src/main/liberty/config/server.xml
+++ b/start/backendServices/src/main/liberty/config/server.xml
@@ -8,10 +8,10 @@
     <feature>persistence-3.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="5050" />
-  <variable name="default.https.port" defaultValue="5051" />
+  <variable name="http.port" defaultValue="5050" />
+  <variable name="https.port" defaultValue="5051" />
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
                 id="defaultHttpEndpoint" host="*" />
 
   <application location="backendServices.war" type="war" context-root="/"></application>

--- a/start/frontendUI/pom.xml
+++ b/start/frontendUI/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>

--- a/start/frontendUI/src/main/liberty/config/server.xml
+++ b/start/frontendUI/src/main/liberty/config/server.xml
@@ -6,14 +6,14 @@
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
     <feature>faces-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9090"/>
-  <variable name="default.https.port" defaultValue="9091"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9091"/>
 
-  <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}"
     id="defaultHttpEndpoint" host="*" />
 
   <application location="frontendUI.war" context-root="/">


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

